### PR TITLE
(backwards incompatible) refact: redesign FrameToArrayConverter

### DIFF
--- a/araviq6/tests/test_videostream.py
+++ b/araviq6/tests/test_videostream.py
@@ -1,8 +1,5 @@
 import cv2  # type: ignore[import]
-import numpy as np
-import qimage2ndarray  # type: ignore[import]
-import pytest
-from araviq6 import VideoProcessWorker, FrameToArrayConverter
+from araviq6 import VideoProcessWorker
 from araviq6.util import VideoProcessWorkerTester, get_samples_path
 from araviq6.qt_compat import QtCore, QtMultimedia
 
@@ -26,20 +23,3 @@ def test_VideoProcessWorker(qtbot):
 
     tester.testVideoFrame(sink.videoFrame())
     player.stop()
-
-
-def test_FrameToArrayConverter(qtbot):
-    bgr_array = cv2.imread(get_samples_path("hello.jpg"))
-    gray_array = cv2.cvtColor(bgr_array, cv2.COLOR_BGR2GRAY)
-    rgb_array = cv2.cvtColor(bgr_array, cv2.COLOR_BGR2RGB)
-
-    gray_img = qimage2ndarray.gray2qimage(gray_array)
-    rgb_img = qimage2ndarray.array2qimage(rgb_array)
-
-    conv = FrameToArrayConverter()
-    assert np.all(conv.convertQImageToArray(rgb_img) == rgb_array)
-    with pytest.raises(ValueError):
-        conv.convertQImageToArray(gray_img)
-
-    conv.setConverter(qimage2ndarray.byte_view)
-    assert np.all(conv.convertQImageToArray(gray_img) == gray_array[..., np.newaxis])

--- a/araviq6/videostream.py
+++ b/araviq6/videostream.py
@@ -225,9 +225,7 @@ class FrameToArrayConverter(QtCore.QObject):
     and then converts to numpy array :meth:`imageToArray`. Resulting array is
     emitted to :attr:`arrayConverted`.
 
-    Since ``QVideoPlayer`` sends dummy video frame at the end of video,
-    :meth:`ignoreNullFrame` determines whether null frame should be ignored or
-    empty array should be emitted.
+    Invalid video frame is converted to 3D empty array.
 
     """
 
@@ -235,20 +233,7 @@ class FrameToArrayConverter(QtCore.QObject):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._ignoreNullFrame = True
         self._converter = qimage2ndarray.rgb_view
-
-    def ignoreNullFrame(self) -> bool:
-        """
-        If True, null ``QVideoFrame`` passed to :meth:`convertVideoFrame` is be
-        ignored. Else, empty array with shape ``(0, 0, 0)`` is emitted.
-        """
-        return self._ignoreNullFrame
-
-    @QtCore.Slot(bool)
-    def setIgnoreNullFrame(self, ignore: bool):
-        """Update :meth:`ignoreNullFrame`."""
-        self._ignoreNullFrame = ignore
 
     @QtCore.Slot(QtMultimedia.QVideoFrame)
     def convertVideoFrame(self, frame: QtMultimedia.QVideoFrame):
@@ -259,10 +244,8 @@ class FrameToArrayConverter(QtCore.QObject):
         qimg = frame.toImage()
         if not qimg.isNull():
             array = self.imageToArray(qimg).copy()  # copy to detach reference
-        elif not self.ignoreNullFrame():
-            array = np.empty((0, 0, 0), dtype=np.uint8)
         else:
-            return
+            array = np.empty((0, 0, 0), dtype=np.uint8)
         self.arrayConverted.emit(array)
 
     def imageToArray(self, image: QtGui.QImage) -> np.ndarray:

--- a/araviq6/videostream.py
+++ b/araviq6/videostream.py
@@ -223,13 +223,13 @@ class FrameToArrayConverter(QtCore.QObject):
 
     :class:`FrameToArrayConverter` first converts ``QVideoFrame`` to ``QImage``
     and then converts to numpy array :meth:`imageToArray`. Resulting array is
-    emitted to :attr:`arrayConverted`.
+    emitted to :attr:`arrayConverted` with original frame.
 
     Invalid video frame is converted to 3D empty array.
 
     """
 
-    arrayConverted = QtCore.Signal(np.ndarray)
+    arrayConverted = QtCore.Signal(np.ndarray, QtMultimedia.QVideoFrame)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -246,7 +246,7 @@ class FrameToArrayConverter(QtCore.QObject):
             array = self.imageToArray(qimg).copy()  # copy to detach reference
         else:
             array = np.empty((0, 0, 0), dtype=np.uint8)
-        self.arrayConverted.emit(array)
+        self.arrayConverted.emit(array, frame)
 
     def imageToArray(self, image: QtGui.QImage) -> np.ndarray:
         """
@@ -261,13 +261,14 @@ class FrameToArrayConverter(QtCore.QObject):
 
 class NDArrayVideoPlayer(QtMultimedia.QMediaPlayer):
     """
-    Minimal implementation of video player which emits frames as numpy arrays to
-    :attr:`arrayChanged` signal.
+    Video player which emits numpy array.
 
-    User may use this class for convenience, or define own pipeline.
+    :class:`NDArrayVideoPlayer` emits the the numpy array and its original frame
+    to :attr:`arrayChanged` signal. User may use this class for convenience, or
+    define own pipeline.
     """
 
-    arrayChanged = QtCore.Signal(np.ndarray)
+    arrayChanged = QtCore.Signal(np.ndarray, QtMultimedia.QVideoFrame)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -283,13 +284,14 @@ class NDArrayVideoPlayer(QtMultimedia.QMediaPlayer):
 
 class NDArrayMediaCaptureSession(QtMultimedia.QMediaCaptureSession):
     """
-    Minimal implementation of media capture session which emits frames as
-    numpy arrays to :attr:`arrayChanged` signal.
+    Capture session which emits numpy array.
 
-    User may use this class for convenience, or define own pipeline.
+    :class:`NDArrayMediaCaptureSession` emits the the numpy array and its
+    original frame to :attr:`arrayChanged` signal. User may use this class for
+    convenience, or define own pipeline.
     """
 
-    arrayChanged = QtCore.Signal(np.ndarray)
+    arrayChanged = QtCore.Signal(np.ndarray, QtMultimedia.QVideoFrame)
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/araviq6/videostream.py
+++ b/araviq6/videostream.py
@@ -219,13 +219,13 @@ class VideoFrameProcessor(QtCore.QObject):
 
 class FrameToArrayConverter(QtCore.QObject):
     """
-    Video pipeline component which converts ``QVideoFrame`` to numpy array and
-    emits to :attr:`arrayConverted`.
+    Video pipeline component which converts ``QVideoFrame`` to numpy array.
 
-    ``QVideoFrame`` is first transformed to ``QImage`` and then converted to
-    array by :meth:`converter`.
+    :class:`FrameToArrayConverter` first converts ``QVideoFrame`` to ``QImage``
+    and then converts to numpy array :meth:`imageToArray`. Resulting array is
+    emitted to :attr:`arrayConverted`.
 
-    ``QVideoPlayer`` sends empty video frame at the end of video.
+    Since ``QVideoPlayer`` sends dummy video frame at the end of video,
     :meth:`ignoreNullFrame` determines whether null frame should be ignored or
     empty array should be emitted.
 

--- a/doc/source/examples/PySide6/array.camera.py
+++ b/doc/source/examples/PySide6/array.camera.py
@@ -30,7 +30,6 @@ class BlurringProcessor(QObject):
     @Slot(np.ndarray)
     def setArray(self, array: np.ndarray):
         self._ready = False
-        array = cv2.cvtColor(array, cv2.COLOR_BGR2RGB)
         self.arrayChanged.emit(cv2.GaussianBlur(array, (0, 0), 25))
         self._ready = True
 

--- a/doc/source/examples/PySide6/array.camera.py
+++ b/doc/source/examples/PySide6/array.camera.py
@@ -50,8 +50,10 @@ class Window(QMainWindow):
         # set up the pipeline
         self._captureSession.setCamera(self._camera)
         self._captureSession.setVideoSink(self._cameraSink)
-        self._cameraSink.videoFrameChanged.connect(self._arrayConverter.setVideoFrame)
-        self._arrayConverter.arrayChanged.connect(self._displayImageFromCamera)
+        self._cameraSink.videoFrameChanged.connect(
+            self._arrayConverter.convertVideoFrame
+        )
+        self._arrayConverter.arrayConverted.connect(self._displayImageFromCamera)
         self._processRequested.connect(self._arrayProcessor.setArray)
         self._arrayProcessor.arrayChanged.connect(self._arrayLabel.setArray)
 

--- a/doc/source/examples/PySide6/array.player.py
+++ b/doc/source/examples/PySide6/array.player.py
@@ -40,14 +40,12 @@ class CannyEdgeDetector(QObject):
 
     def setArray(self, array: np.ndarray):
         self._ready = False
-        if array.size == 0:
-            ret = array
-        elif self.cannyMode():
+        if array.size != 0 and self.cannyMode():
             gray = cv2.cvtColor(array, cv2.COLOR_RGB2GRAY)
             canny = cv2.Canny(gray, 50, 200)
             ret = cv2.cvtColor(canny, cv2.COLOR_GRAY2RGB)
         else:
-            ret = cv2.cvtColor(array, cv2.COLOR_BGR2RGB)
+            ret = array
         self.arrayChanged.emit(ret)
         self._ready = True
 


### PR DESCRIPTION
* Modify conversion method
* Remove `ignoreNullFrame`
* Modify signal/slot