### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,8 @@ build:
 python:
   install:
     - method: pip
+      path: typing_extensions
+    - method: pip
       path: .
       extra_requirements:
         - doc

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,6 @@ build:
 
 python:
   install:
-    - method: pip
-      path: typing_extensions
-    - method: pip
-      path: .
+    - path: .
       extra_requirements:
         - doc

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -2,3 +2,4 @@ numpydoc
 sphinx
 sphinx-tabs
 sphinx_rtd_theme
+typing_extensions


### PR DESCRIPTION
Try fix ModuleNotFoundError: No module named 'typing_extensions'